### PR TITLE
Add authenticated sockets and account-driven frontend

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,4 +1,4 @@
-import { Message, ServerSummary } from './types';
+import { AuthUser, Message, ServerSummary, TransportMode } from './types';
 
 const API_BASE = '/api';
 
@@ -9,6 +9,7 @@ async function request<T>(url: string, init?: RequestInit): Promise<T> {
       ...(init && init.headers ? init.headers : {}),
     },
     ...init,
+    credentials: 'include',
   });
 
   if (!response.ok) {
@@ -53,12 +54,64 @@ export async function createChannel(serverId: string, payload: { name: string; t
   );
 }
 
-export async function persistMessage(serverId: string, channelId: string, message: Message) {
-  return request<{ message: Message }>(
-    `${API_BASE}/servers/${serverId}/channels/${channelId}/messages`,
-    {
-      method: 'POST',
-      body: JSON.stringify(message),
-    }
-  );
+export async function persistMessage(
+  serverId: string,
+  channelId: string,
+  payload: { id?: string; content: string; transport?: TransportMode; timestamp?: string }
+) {
+  return request<{ message: Message }>(`${API_BASE}/servers/${serverId}/channels/${channelId}/messages`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function registerAccount(payload: {
+  email: string;
+  password: string;
+  displayName?: string;
+  avatarUrl?: string;
+  accentColor?: string;
+}): Promise<AuthUser> {
+  const { user } = await request<{ user: AuthUser }>(`${API_BASE}/auth/register`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  return user;
+}
+
+export async function login(payload: { email: string; password: string }): Promise<AuthUser> {
+  const { user } = await request<{ user: AuthUser }>(`${API_BASE}/auth/login`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  return user;
+}
+
+export async function logout(): Promise<void> {
+  await request<{ ok: boolean }>(`${API_BASE}/auth/logout`, { method: 'POST' });
+}
+
+export async function fetchCurrentUser(): Promise<AuthUser | null> {
+  const response = await fetch(`${API_BASE}/me`, { credentials: 'include' });
+  if (response.status === 401) {
+    return null;
+  }
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || response.statusText);
+  }
+  const data = (await response.json()) as { user: AuthUser };
+  return data.user;
+}
+
+export async function updateProfile(payload: {
+  displayName?: string;
+  avatarUrl?: string;
+  accentColor?: string;
+}): Promise<AuthUser> {
+  const { user } = await request<{ user: AuthUser }>(`${API_BASE}/me`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+  return user;
 }

--- a/client/src/components/AuthScreen.tsx
+++ b/client/src/components/AuthScreen.tsx
@@ -1,0 +1,90 @@
+import { FormEvent, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+type Mode = 'login' | 'register';
+
+export function AuthScreen() {
+  const { signIn, signUp, pending } = useAuth();
+  const [mode, setMode] = useState<Mode>('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const toggleMode = () => {
+    setMode((prev) => (prev === 'login' ? 'register' : 'login'));
+    setError(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      if (mode === 'login') {
+        await signIn({ email, password });
+      } else {
+        await signUp({ email, password, displayName: displayName || undefined });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Authentication failed';
+      setError(message);
+    }
+  };
+
+  const submitDisabled = !email.trim() || !password.trim() || (mode === 'register' && !displayName.trim()) || pending;
+
+  return (
+    <div className="auth-screen">
+      <div className="auth-card">
+        <h1>Welcome to ChatClient</h1>
+        <p className="auth-card__subtitle">
+          {mode === 'login' ? 'Sign in to continue the conversation.' : 'Create an account to join the conversation.'}
+        </p>
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <label>
+            Email address
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              autoComplete="email"
+              required
+            />
+          </label>
+          <label>
+            Password
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+              required
+              minLength={8}
+            />
+          </label>
+          {mode === 'register' && (
+            <label>
+              Display name
+              <input
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+                autoComplete="nickname"
+                required
+              />
+            </label>
+          )}
+          {error && <div className="auth-form__error">{error}</div>}
+          <button type="submit" disabled={submitDisabled}>
+            {pending ? 'Please wait…' : mode === 'login' ? 'Sign in' : 'Create account'}
+          </button>
+        </form>
+        <p className="auth-card__switch">
+          {mode === 'login' ? 'Need an account?' : 'Already have an account?'}{' '}
+          <button type="button" onClick={toggleMode} disabled={pending}>
+            {mode === 'login' ? 'Register' : 'Sign in'}
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/MessageList.tsx
+++ b/client/src/components/MessageList.tsx
@@ -52,8 +52,18 @@ export function MessageList({ messages, currentUserId }: MessageListProps) {
             })}
           >
             {!isSystem && (
-              <div className="message-list__avatar" style={{ backgroundColor: avatarColor }} aria-hidden={true}>
-                {initials}
+              <div
+                className={clsx('message-list__avatar', {
+                  'message-list__avatar--image': Boolean(message.author.avatarUrl),
+                })}
+                style={message.author.avatarUrl ? undefined : { backgroundColor: avatarColor }}
+                aria-hidden={true}
+              >
+                {message.author.avatarUrl ? (
+                  <img src={message.author.avatarUrl} alt="" />
+                ) : (
+                  initials
+                )}
               </div>
             )}
             <div className="message-list__body">

--- a/client/src/components/UserProfileModal.tsx
+++ b/client/src/components/UserProfileModal.tsx
@@ -4,12 +4,16 @@ interface UserProfileModalProps {
   open: boolean;
   initialName: string;
   initialColor: string;
-  onSave: (name: string, color: string) => void;
+  onSave: (name: string, color: string) => Promise<void> | void;
+  onClose?: () => void;
+  saving?: boolean;
 }
 
-export function UserProfileModal({ open, initialName, initialColor, onSave }: UserProfileModalProps) {
+export function UserProfileModal({ open, initialName, initialColor, onSave, onClose, saving }: UserProfileModalProps) {
   const [name, setName] = useState(initialName);
   const [color, setColor] = useState(initialColor);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     setName(initialName);
@@ -21,18 +25,27 @@ export function UserProfileModal({ open, initialName, initialColor, onSave }: Us
 
   if (!open) return null;
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const trimmed = name.trim();
     if (!trimmed) return;
-    onSave(trimmed, color);
+    setError(null);
+    try {
+      setSubmitting(true);
+      await onSave(trimmed, color);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update profile';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
     <div className="user-profile-modal">
       <form className="user-profile-modal__content" onSubmit={handleSubmit}>
-        <h2>Choose your display name</h2>
-        <p>You can change this later from the settings menu.</p>
+        <h2>Update your profile</h2>
+        <p>Set how others will see you across servers.</p>
         <label>
           Display name
           <input value={name} onChange={(event) => setName(event.target.value)} placeholder="e.g. Ada Lovelace" />
@@ -46,9 +59,15 @@ export function UserProfileModal({ open, initialName, initialColor, onSave }: Us
             </button>
           </div>
         </label>
-        <button type="submit" disabled={!name.trim()}>
-          Join Chat
-        </button>
+        {error && <div className="user-profile-modal__error">{error}</div>}
+        <div className="user-profile-modal__actions">
+          <button type="button" onClick={onClose} disabled={submitting || saving}>
+            Cancel
+          </button>
+          <button type="submit" disabled={!name.trim() || submitting || saving}>
+            {submitting || saving ? 'Saving…' : 'Save changes'}
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -1,0 +1,121 @@
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  fetchCurrentUser,
+  login,
+  logout,
+  registerAccount,
+  updateProfile as updateProfileRequest,
+} from '../api';
+import { AuthUser } from '../types';
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  initializing: boolean;
+  pending: boolean;
+  signIn: (credentials: { email: string; password: string }) => Promise<AuthUser>;
+  signUp: (payload: { email: string; password: string; displayName?: string }) => Promise<AuthUser>;
+  signOut: () => Promise<void>;
+  refresh: () => Promise<AuthUser | null>;
+  updateProfile: (updates: { displayName?: string; avatarUrl?: string; accentColor?: string }) => Promise<AuthUser>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [initializing, setInitializing] = useState(true);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchCurrentUser()
+      .then((current) => {
+        if (!cancelled) {
+          setUser(current);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setUser(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setInitializing(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function runWithPending<T>(operation: () => Promise<T>): Promise<T> {
+    setPending(true);
+    try {
+      return await operation();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const signIn = (credentials: { email: string; password: string }) =>
+    runWithPending(async () => {
+      const next = await login(credentials);
+      setUser(next);
+      return next;
+    });
+
+  const signUp = (payload: { email: string; password: string; displayName?: string }) =>
+    runWithPending(async () => {
+      const next = await registerAccount(payload);
+      setUser(next);
+      return next;
+    });
+
+  const signOut = () =>
+    runWithPending(async () => {
+      await logout();
+      setUser(null);
+    });
+
+  const refresh = async () => {
+    const current = await fetchCurrentUser();
+    setUser(current);
+    return current;
+  };
+
+  const updateProfile = (updates: { displayName?: string; avatarUrl?: string; accentColor?: string }) =>
+    runWithPending(async () => {
+      const updated = await updateProfileRequest(updates);
+      setUser(updated);
+      return updated;
+    });
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      initializing,
+      pending,
+      signIn,
+      signUp,
+      signOut,
+      refresh,
+      updateProfile,
+    }),
+    [user, initializing, pending]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/client/src/context/SocketContext.tsx
+++ b/client/src/context/SocketContext.tsx
@@ -10,6 +10,7 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
     socketRef.current = io('/', {
       autoConnect: false,
       transports: ['websocket'],
+      withCredentials: true,
     });
   }
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/global.css';
+import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/client/src/styles/App.css
+++ b/client/src/styles/App.css
@@ -7,6 +7,110 @@
   transition: background 0.35s ease, color 0.35s ease;
 }
 
+.auth-screen {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  color: var(--text-primary);
+  padding: 32px;
+}
+
+.auth-card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 32px;
+  width: min(420px, 100%);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.auth-card h1 {
+  margin: 0;
+  font-size: 1.9rem;
+}
+
+.auth-card__subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.92rem;
+}
+
+.auth-form input {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--surface-alt);
+  color: inherit;
+}
+
+.auth-form button[type='submit'] {
+  border: none;
+  border-radius: 14px;
+  padding: 12px 18px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 16px 28px var(--accent-glow);
+  transition: transform 0.2s ease;
+}
+
+.auth-form button[type='submit']:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.auth-form button[type='submit']:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.auth-form__error {
+  background: rgba(239, 68, 68, 0.12);
+  color: #ef4444;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 0.88rem;
+}
+
+.auth-card__switch {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.auth-card__switch button {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.auth-screen--loading .auth-card {
+  box-shadow: none;
+  background: transparent;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+}
+
 .server-sidebar,
 .channel-sidebar,
 .message-list,
@@ -258,6 +362,7 @@
   align-items: center;
   gap: 12px;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .server-banner__theme-toggle {
@@ -298,6 +403,80 @@
   padding: 0;
   cursor: pointer;
   background: transparent;
+}
+
+.server-banner__account {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.server-banner__profile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(15, 23, 42, 0.18);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+  backdrop-filter: blur(4px);
+}
+
+.server-banner__profile:hover {
+  transform: translateY(-1px);
+  background: rgba(15, 23, 42, 0.28);
+}
+
+.server-banner__avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent-contrast);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
+}
+
+.server-banner__profile-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  text-align: left;
+}
+
+.server-banner__profile-meta span {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.server-banner__signout {
+  border: none;
+  border-radius: 14px;
+  padding: 10px 16px;
+  background: rgba(15, 23, 42, 0.18);
+  color: inherit;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  transition: background 0.2s ease, transform 0.2s ease;
+  backdrop-filter: blur(4px);
+}
+
+.server-banner__signout:hover {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.35);
+  transform: translateY(-1px);
+}
+
+.server-banner__signout:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .chat-header {
@@ -431,6 +610,19 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
+}
+
+.message-list__avatar--image {
+  padding: 0;
+  box-shadow: none;
+  background: transparent;
+}
+
+.message-list__avatar--image img {
+  width: 100%;
+  height: 100%;
+  border-radius: 14px;
+  object-fit: cover;
 }
 
 .message-list__body {
@@ -723,26 +915,50 @@
   box-shadow: 0 12px 26px var(--accent-glow);
 }
 
-.user-profile-modal__content button[type='submit'] {
-  border: none;
+.user-profile-modal__error {
+  background: rgba(239, 68, 68, 0.12);
+  color: #ef4444;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 0.88rem;
+}
+
+.user-profile-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.user-profile-modal__actions button {
   border-radius: 14px;
   padding: 12px 18px;
-  background: var(--accent);
-  color: var(--accent-contrast);
   font-weight: 600;
   cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.user-profile-modal__actions button:first-of-type {
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text-secondary);
+}
+
+.user-profile-modal__actions button:last-of-type {
+  border: none;
+  background: var(--accent);
+  color: var(--accent-contrast);
   box-shadow: 0 16px 28px var(--accent-glow);
-  transition: transform 0.2s ease;
 }
 
-.user-profile-modal__content button[type='submit']:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.user-profile-modal__content button[type='submit']:not(:disabled):hover {
+.user-profile-modal__actions button:last-of-type:hover {
   transform: translateY(-1px);
+}
+
+.user-profile-modal__actions button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 @media (max-width: 1100px) {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -5,6 +5,7 @@ export interface Member {
   userId: string;
   username: string;
   color: string;
+  avatarUrl?: string;
 }
 
 export interface MessageAuthor {
@@ -12,6 +13,7 @@ export interface MessageAuthor {
   name: string;
   color: string;
   socketId?: string;
+  avatarUrl?: string;
 }
 
 export interface ChannelSummary {
@@ -49,4 +51,15 @@ export interface ChannelEvent {
   type: 'user-joined' | 'user-left';
   user: Member;
   reason?: string;
+}
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  displayName: string;
+  avatarUrl: string;
+  accentColor: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
 }

--- a/docs/architecture-plan.md
+++ b/docs/architecture-plan.md
@@ -42,8 +42,8 @@ The goal is to evolve the application toward production-ready collaboration feat
   - ~~`POST /api/auth/login`~~
   - ~~`POST /api/auth/logout`~~
   - ~~`GET /api/me` – returns profile + preferences.~~
-- **Socket**: Authenticate connections via token; include `userId` in `register` payloads. Maintain presence keyed by user ID.
-- **Frontend**: Add auth routes (sign-in/up forms), global auth context, secure storage of tokens, profile settings page.
+- ~~**Socket**: Authenticate connections via token; include `userId` in `register` payloads. Maintain presence keyed by user ID.~~
+- ~~**Frontend**: Add auth routes (sign-in/up forms), global auth context, secure storage of tokens, profile settings page.~~
 - **Persistence**: Replace JSON file with relational DB. Provide migration script to import existing demo users (optional).
 - **Security**: Rate-limit auth endpoints, sanitize avatar uploads.
 

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -121,4 +121,5 @@ module.exports = {
   AUTH_COOKIE_NAME,
   DEFAULT_SESSION_TTL,
   createAuthHandlers,
+  parseCookies,
 };


### PR DESCRIPTION
## Summary
- authenticate Socket.IO connections against issued sessions, maintain presence keyed by account, and expose a profile update route
- add a React auth context with login/register screen and gate the chat UI on authenticated state, refreshing socket presence when profiles change
- refresh styling for the new auth/profile UX and document the completed roadmap items

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68cafd6defbc832dac29ce292a623f50