### PR TITLE
Add realtime typing indicators for channels

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import { ServerSidebar } from './components/ServerSidebar';
 import { ChannelSidebar } from './components/ChannelSidebar';
 import { MessageList } from './components/MessageList';
 import { MessageComposer, ComposerPayload } from './components/MessageComposer';
+import { TypingIndicator } from './components/TypingIndicator';
 import { TransportToggle } from './components/TransportToggle';
 import { MemberList } from './components/MemberList';
 import { UserProfileModal } from './components/UserProfileModal';
@@ -109,6 +110,7 @@ function ChatApp() {
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
   const [messages, dispatchMessages] = useReducer(messagesReducer, {});
   const [members, setMembers] = useState<Member[]>([]);
+  const [typingByRoom, setTypingByRoom] = useState<Record<string, Member[]>>({});
   const [transportMode, setTransportMode] = useState<TransportMode>(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('chatclient.transport');
@@ -139,6 +141,16 @@ function ChatApp() {
     return messages[channelKey(selectedServerId, selectedChannelId)] ?? [];
   }, [messages, selectedServerId, selectedChannelId]);
 
+  const typingMembers = useMemo(() => {
+    if (!selectedServerId || !selectedChannelId) return [] as Member[];
+    const key = channelKey(selectedServerId, selectedChannelId);
+    const roomTypers = typingByRoom[key] ?? [];
+    if (!user?.id) {
+      return roomTypers;
+    }
+    return roomTypers.filter((member) => member.userId !== user.id);
+  }, [typingByRoom, selectedServerId, selectedChannelId, user?.id]);
+
   const serverAccent = currentServer?.accentColor || accentColor;
 
   const serverBannerStyle = useMemo(() => {
@@ -162,6 +174,7 @@ function ChatApp() {
       setMembers([]);
       setSelfMember(null);
       setCurrentRoom(null);
+      setTypingByRoom({});
       dispatchMessages({ type: 'reset' });
       return;
     }
@@ -224,6 +237,7 @@ function ChatApp() {
 
     const handleDisconnect = () => {
       setConnectionState('disconnected');
+      setTypingByRoom({});
     };
 
     const handleMessage = (payload: { type: string; message: Message }) => {
@@ -279,12 +293,31 @@ function ChatApp() {
       setConnectionState('disconnected');
     };
 
+    const handleTypingUpdate = (payload: { room: string; serverId: string; channelId: string; typers: Member[] }) => {
+      if (!payload?.serverId || !payload?.channelId) {
+        return;
+      }
+      const key = channelKey(payload.serverId, payload.channelId);
+      setTypingByRoom((prev) => {
+        if (!payload.typers || payload.typers.length === 0) {
+          if (!prev[key]) {
+            return prev;
+          }
+          const { [key]: _removed, ...rest } = prev;
+          return rest;
+        }
+        const next = { ...prev, [key]: payload.typers };
+        return next;
+      });
+    };
+
     socket.on('connect', handleConnect);
     socket.on('disconnect', handleDisconnect);
     socket.on('message', handleMessage);
     socket.on('presence-update', handlePresence);
     socket.on('channel-event', handleChannelEvent);
     socket.on('connect_error', handleConnectError);
+    socket.on('typing-update', handleTypingUpdate);
 
     if (socket.connected) {
       handleConnect();
@@ -300,6 +333,7 @@ function ChatApp() {
       socket.off('presence-update', handlePresence);
       socket.off('channel-event', handleChannelEvent);
       socket.off('connect_error', handleConnectError);
+      socket.off('typing-update', handleTypingUpdate);
     };
   }, [socket, user, selectedServerId, selectedChannelId, currentRoom]);
 
@@ -311,6 +345,18 @@ function ChatApp() {
       }
     });
   }, [socket, user?.displayName, user?.accentColor, user?.avatarUrl]);
+
+  useEffect(() => {
+    if (!selectedServerId || !selectedChannelId) {
+      setTypingByRoom({});
+      return;
+    }
+    const key = channelKey(selectedServerId, selectedChannelId);
+    setTypingByRoom((prev) => {
+      const existing = prev[key];
+      return existing ? { [key]: existing } : {};
+    });
+  }, [selectedServerId, selectedChannelId]);
 
   useEffect(() => {
     if (!socket || !socket.connected || !user || !selectedServerId || !selectedChannelId) return;
@@ -329,6 +375,7 @@ function ChatApp() {
       socket.emit('leave-channel');
       setMembers([]);
       setCurrentRoom(null);
+      setTypingByRoom({});
     };
   }, [socket, user, selectedServerId, selectedChannelId]);
 
@@ -351,6 +398,18 @@ function ChatApp() {
     };
     dispatchMessages({ type: 'add', serverId: normalized.serverId, channelId: normalized.channelId, message: normalized });
   }, []);
+
+  const handleTypingStart = useCallback(() => {
+    if (!socket || !socket.connected) return;
+    if (!selectedServerId || !selectedChannelId) return;
+    socket.emit('typing-start', { serverId: selectedServerId, channelId: selectedChannelId });
+  }, [socket, selectedServerId, selectedChannelId]);
+
+  const handleTypingStop = useCallback(() => {
+    if (!socket || !socket.connected) return;
+    if (!selectedServerId || !selectedChannelId) return;
+    socket.emit('typing-stop', { serverId: selectedServerId, channelId: selectedChannelId });
+  }, [socket, selectedServerId, selectedChannelId]);
 
   const { peers: p2pPeers, sendMessage: sendPeerMessage, isActive: isP2PActive } = useP2P({
     socket,
@@ -634,11 +693,14 @@ function ChatApp() {
           </div>
         </header>
         <MessageList messages={currentMessages} currentUserId={user.id} />
+        <TypingIndicator typers={typingMembers} />
         <MessageComposer
           disabled={composerDisabled}
           onSend={handleSendMessage}
           transportLabel={transportLabel}
           placeholder={composerPlaceholder}
+          onTypingStart={handleTypingStart}
+          onTypingStop={handleTypingStop}
         />
       </section>
       <MemberList members={members} currentUserId={user.id} />

--- a/client/src/components/TypingIndicator.tsx
+++ b/client/src/components/TypingIndicator.tsx
@@ -1,0 +1,42 @@
+import { Member } from '../types';
+
+interface TypingIndicatorProps {
+  typers: Member[];
+}
+
+function formatTypingMessage(typers: Member[]): string {
+  const names = typers.map((member) => member.username || 'Someone');
+  if (names.length === 0) {
+    return '';
+  }
+  if (names.length === 1) {
+    return `${names[0]} is typing…`;
+  }
+  if (names.length === 2) {
+    return `${names[0]} and ${names[1]} are typing…`;
+  }
+  const [first, second, third, ...rest] = names;
+  if (names.length === 3) {
+    return `${first}, ${second}, and ${third} are typing…`;
+  }
+  return `${first}, ${second}, and ${rest.length + 1} others are typing…`;
+}
+
+export function TypingIndicator({ typers }: TypingIndicatorProps) {
+  if (!typers || typers.length === 0) {
+    return null;
+  }
+  const message = formatTypingMessage(typers);
+  return (
+    <div className="typing-indicator" role="status" aria-live="polite">
+      <span className="typing-indicator__text">{message}</span>
+      <span className="typing-indicator__dots" aria-hidden="true">
+        <span className="typing-indicator__dot" />
+        <span className="typing-indicator__dot" />
+        <span className="typing-indicator__dot" />
+      </span>
+    </div>
+  );
+}
+
+export default TypingIndicator;

--- a/client/src/styles/App.css
+++ b/client/src/styles/App.css
@@ -1212,6 +1212,60 @@
   box-shadow: none;
 }
 
+.typing-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin: 4px 24px 12px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  font-size: 0.9rem;
+  align-self: flex-start;
+}
+
+.typing-indicator__text {
+  white-space: nowrap;
+}
+
+.typing-indicator__dots {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.typing-indicator__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  opacity: 0.65;
+  animation: typing-indicator-bounce 1.2s infinite ease-in-out;
+}
+
+.typing-indicator__dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.typing-indicator__dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes typing-indicator-bounce {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.65);
+    opacity: 0.4;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
 @media (max-width: 1100px) {
   .app-shell {
     grid-template-columns: 88px 260px minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- track per-room typing memberships on the server and broadcast throttled typing updates
- manage per-channel typing state on the client and surface a footer indicator component
- emit typing start/stop events from the composer with an inactivity debounce across server and P2P modes

## Testing
- npm run build (client)


------
https://chatgpt.com/codex/tasks/task_e_68d312f332f4832db9cda864d42a54c9